### PR TITLE
fix: 全文検索のデータベース型と関数を最適化

### DIFF
--- a/supabase/migrations/20250304030458_createfull_text_search_function.sql
+++ b/supabase/migrations/20250304030458_createfull_text_search_function.sql
@@ -1,10 +1,17 @@
-CREATE INDEX pgroonga_index_tags_name ON public.tags USING pgroonga (name) WITH (tokenizer='TokenBigram');
+CREATE TYPE public.search_task AS (
+  id text,
+  title text
+);
 
-CREATE INDEX pgroonga_index_tasks_description ON public.tasks USING pgroonga (description) WITH (tokenizer='TokenBigram');
+CREATE TYPE public.search_tag AS (
+  id text,
+  name text
+);
 
-CREATE INDEX pgroonga_index_tasks_title ON public.tasks USING pgroonga (title) WITH (tokenizer='TokenBigram');
-
-set check_function_bodies = off;
+CREATE TYPE public.search_result AS (
+  tasks search_task[],
+  tags search_tag[]
+);
 
 CREATE OR REPLACE FUNCTION public.full_text_search(query text)
  RETURNS search_result
@@ -31,13 +38,17 @@ BEGIN
 
   RETURN result;
 END;
-$function$
-;
-
-create type "public"."search_result" as ("tasks" search_task[], "tags" search_tag[]);
-
-create type "public"."search_tag" as ("id" text, "name" text);
-
-create type "public"."search_task" as ("id" text, "title" text);
+$function$;
 
 
+CREATE INDEX pgroonga_index_tags_name
+  ON public.tags USING pgroonga (name)
+  WITH (tokenizer='TokenBigram');
+
+CREATE INDEX pgroonga_index_tasks_description
+  ON public.tasks USING pgroonga (description)
+  WITH (tokenizer='TokenBigram');
+
+CREATE INDEX pgroonga_index_tasks_title
+  ON public.tasks USING pgroonga (title)
+  WITH (tokenizer='TokenBigram');


### PR DESCRIPTION
- 検索結果のための型定義を明確に分離
- `search_task`, `search_tag`, `search_result` 型を追加
- 全文検索関数 `full_text_search` の実装を整理
- PGroongaインデックスの作成を整形し、可読性を向上